### PR TITLE
Simplify CommandInfo class.

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -122,9 +122,9 @@ class AnnotatedCommand extends Command
 
     protected function setCommandArgumentsFromParameters($commandInfo)
     {
-        $args = $commandInfo->getArguments();
+        $args = $commandInfo->arguments()->getValues();
         foreach ($args as $name => $defaultValue) {
-            $description = $commandInfo->getArgumentDescription($name);
+            $description = $commandInfo->arguments()->getDescription($name);
             $parameterMode = $this->getCommandArgumentMode($defaultValue);
             $this->addArgument($name, $parameterMode, $description, $defaultValue);
         }
@@ -143,9 +143,9 @@ class AnnotatedCommand extends Command
 
     protected function setCommandOptions($commandInfo)
     {
-        $opts = $commandInfo->getOptions();
+        $opts = $commandInfo->options()->getValues();
         foreach ($opts as $name => $val) {
-            $description = $commandInfo->getOptionDescription($name);
+            $description = $commandInfo->options()->getDescription($name);
 
             $fullName = $name;
             $shortcut = '';

--- a/src/CommandDocBlockParser.php
+++ b/src/CommandDocBlockParser.php
@@ -101,7 +101,7 @@ class CommandDocBlockParser
         $variableName = $tag->getVariableName();
         $variableName = str_replace('$', '', $variableName);
         $description = static::removeLineBreaks($tag->getDescription());
-        $this->commandInfo->addArgument($variableName, $description);
+        $this->commandInfo->arguments()->add($variableName, $description);
     }
 
     /**
@@ -128,7 +128,7 @@ class CommandDocBlockParser
         $variableName = $this->commandInfo->findMatchingOption($match['name']);
         $desc = $match['description'];
         $description = static::removeLineBreaks($desc);
-        $this->commandInfo->addOption($variableName, $description);
+        $this->commandInfo->options()->add($variableName, $description);
     }
 
     /**
@@ -142,13 +142,13 @@ class CommandDocBlockParser
         }
         $variableName = $match['name'];
         $defaultValue = $this->interpretDefaultValue($match['description']);
-        if ($this->commandInfo->hasArgument($variableName)) {
-            $this->commandInfo->setArgumentDefaultValue($variableName, $defaultValue);
+        if ($this->commandInfo->arguments()->exists($variableName)) {
+            $this->commandInfo->arguments()->setDefaultValue($variableName, $defaultValue);
             return;
         }
         $variableName = $this->commandInfo->findMatchingOption($variableName);
-        if ($this->commandInfo->hasOption($variableName)) {
-            $this->commandInfo->setOptionDefaultValue($variableName, $defaultValue);
+        if ($this->commandInfo->options()->exists($variableName)) {
+            $this->commandInfo->options()->setDefaultValue($variableName, $defaultValue);
         }
     }
 

--- a/src/CommandInfo.php
+++ b/src/CommandInfo.php
@@ -260,119 +260,23 @@ class CommandInfo
     }
 
     /**
-     * Return the commandline arguments for this command. The key
-     * contains the name of the argument, and the value contains its
-     * default value. Required commands have a 'null' value.
+     * Descriptions of commandline arguements for this command.
      *
-     * @return array
+     * @return DefaultsWithDescriptions
      */
-    public function getArguments()
+    public function arguments()
     {
-        return $this->arguments->getValues();
+        return $this->arguments;
     }
 
     /**
-     * Check to see if an argument with the specified name exits.
+     * Descriptions of commandline options for this command.
      *
-     * @param string $name Argument to test for.
-     * @return boolean
+     * @return DefaultsWithDescriptions
      */
-    public function hasArgument($name)
+    public function options()
     {
-        return $this->arguments->exists($name);
-    }
-
-    /**
-     * Set the default value for an argument. A default value of 'null'
-     * indicates that the argument is required.
-     *
-     * @param string $name Name of argument to modify.
-     * @param string $defaultValue New default value for that argument.
-     */
-    public function setArgumentDefaultValue($name, $defaultValue)
-    {
-        $this->arguments->setDefaultValue($name, $defaultValue);
-    }
-
-    /**
-     * Add another argument to this command.
-     *
-     * @param string $name Name of the argument.
-     * @param string $description Help text for the argument.
-     * @param string $defaultValue The default value for the argument.
-     */
-    public function addArgument($name, $description, $defaultValue = null)
-    {
-        $this->arguments->add($name, $description, $defaultValue);
-    }
-
-    /**
-     * Return the options for is command. The key is the options name,
-     * and the value is its default value.
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options->getValues();
-    }
-
-    /**
-     * Check to see if the specified option exists.
-     *
-     * @param string $name Name of the option to check.
-     * @return boolean
-     */
-    public function hasOption($name)
-    {
-        return $this->options->exists($name);
-    }
-
-    /**
-     * Change the default value for an option.
-     *
-     * @param string $name Option name.
-     * @param string $defaultValue Option default value.
-     */
-    public function setOptionDefaultValue($name, $defaultValue)
-    {
-        $this->options->setDefaultValue($name, $defaultValue);
-    }
-
-    /**
-     * Add another option to this command.
-     *
-     * @param string $name Option name.
-     * @param string $description Option description.
-     * @param string $defaultValue Option default value.
-     */
-    public function addOption($name, $description, $defaultValue = null)
-    {
-        $this->options->add($name, $description, $defaultValue);
-    }
-
-    /**
-     * Get the description of one argument.
-     *
-     * @param string $name The name of the argument.
-     * @return string
-     */
-    public function getArgumentDescription($name)
-    {
-        $this->parseDocBlock();
-        return $this->arguments->getDescription($name);
-    }
-
-    /**
-     * Get the description of one argument.
-     *
-     * @param string $name The name of the option.
-     * @return string
-     */
-    public function getOptionDescription($name)
-    {
-        $this->parseDocBlock();
-        return $this->options->getDescription($name);
+        return $this->options;
     }
 
     /**

--- a/tests/testCommandInfo.php
+++ b/tests/testCommandInfo.php
@@ -38,15 +38,15 @@ class CommandInfoTests extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(
             'The first number to add.',
-            $commandInfo->getArgumentDescription('one')
+            $commandInfo->arguments()->getDescription('one')
         );
         $this->assertEquals(
             'The other number to add.',
-            $commandInfo->getArgumentDescription('two')
+            $commandInfo->arguments()->getDescription('two')
         );
         $this->assertEquals(
             'Whether or not the result should be negated.',
-            $commandInfo->getOptionDescription('negate')
+            $commandInfo->options()->getDescription('negate')
         );
     }
 }


### PR DESCRIPTION
Remove CommandInfo wrappers around DefaultsWithDescriptions (arguments and options) objects.