### PR TITLE
Pedantic PR - Correct concatenate spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ class MyCommandClass
     /**
      * This is the my:cat command
      *
-     * This command will concatinate two parameters. If the --flip flag
-     * is provided, then the result is the concatination of two and one.
+     * This command will concatenate two parameters. If the --flip flag
+     * is provided, then the result is the concatenation of two and one.
      *
      * @param integer $one The first parameter.
      * @param integer $two The other parameter.
      * @option $flip Whether or not the second parameter should come first in the result.
      * @aliases c
      * @usage bet alpha --flip
-     *   Concatinate "alpha" and "bet".
+     *   Concatenate "alpha" and "bet".
      */
     public function myCat($one, $two, $options = ['flip' => false])
     {

--- a/tests/src/ExampleAnnotatedCommand.php
+++ b/tests/src/ExampleAnnotatedCommand.php
@@ -30,8 +30,8 @@ class ExampleAnnotatedCommand extends AnnotatedCommand
     /**
      * This is the my:cat command implemented as an AnnotatedCommand subclass.
      *
-     * This command will concatinate two parameters. If the --flip flag
-     * is provided, then the result is the concatination of two and one.
+     * This command will concatenate two parameters. If the --flip flag
+     * is provided, then the result is the concatenation of two and one.
      *
      * @command my:cat
      * @arg string $one The first parameter.
@@ -40,7 +40,7 @@ class ExampleAnnotatedCommand extends AnnotatedCommand
      * @option boolean $flip Whether or not the second parameter should come first in the result.
      * @aliases c
      * @usage bet alpha --flip
-     *   Concatinate "alpha" and "bet".
+     *   Concatenate "alpha" and "bet".
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -26,15 +26,15 @@ class ExampleCommandFile
     /**
      * This is the my:cat command
      *
-     * This command will concatinate two parameters. If the --flip flag
-     * is provided, then the result is the concatination of two and one.
+     * This command will concatenate two parameters. If the --flip flag
+     * is provided, then the result is the concatenation of two and one.
      *
      * @param string $one The first parameter.
      * @param string $two The other parameter.
      * @option boolean $flip Whether or not the second parameter should come first in the result.
      * @aliases c
      * @usage bet alpha --flip
-     *   Concatinate "alpha" and "bet".
+     *   Concatenate "alpha" and "bet".
      */
     public function myCat($one, $two = '', $options = ['flip' => false])
     {
@@ -47,13 +47,13 @@ class ExampleCommandFile
     /**
      * This is a command with no options
      *
-     * This command will concatinate two parameters.
+     * This command will concatenate two parameters.
      *
      * @param $one The first parameter.
      * @param $two The other parameter.
      * @aliases nope
      * @usage alpha bet
-     *   Concatinate "alpha" and "bet".
+     *   Concatenate "alpha" and "bet".
      */
     public function commandWithNoOptions($one, $two = 'default')
     {

--- a/tests/testAnnotatedCommand.php
+++ b/tests/testAnnotatedCommand.php
@@ -17,7 +17,7 @@ class AnnotatedCommandTests extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
         $this->assertEquals('my:cat', $command->getName());
         $this->assertEquals('This is the my:cat command implemented as an AnnotatedCommand subclass.', $command->getDescription());
-        $this->assertEquals("This command will concatinate two parameters. If the --flip flag\nis provided, then the result is the concatination of two and one.", $command->getHelp());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
         $this->assertEquals('c', implode(',', $command->getAliases()));
         // Symfony Console composes the synopsis; perhaps we should not test it. Remove if this gives false failures.
         $this->assertEquals('my:cat [--flip] [--] <one> [<two>]', $command->getSynopsis());

--- a/tests/testAnnotatedCommandFactory.php
+++ b/tests/testAnnotatedCommandFactory.php
@@ -45,7 +45,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
         $this->assertEquals('my:cat', $command->getName());
         $this->assertEquals('This is the my:cat command', $command->getDescription());
-        $this->assertEquals("This command will concatinate two parameters. If the --flip flag\nis provided, then the result is the concatination of two and one.", $command->getHelp());
+        $this->assertEquals("This command will concatenate two parameters. If the --flip flag\nis provided, then the result is the concatenation of two and one.", $command->getHelp());
         $this->assertEquals('c', implode(',', $command->getAliases()));
         $this->assertEquals('my:cat [--flip] [--] <one> [<two>]', $command->getSynopsis());
         $this->assertEquals('my:cat bet alpha --flip', implode(',', $command->getUsages()));
@@ -87,7 +87,7 @@ class AnnotatedCommandFactoryTests extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Symfony\Component\Console\Command\Command', $command);
         $this->assertEquals('command:with-no-options', $command->getName());
         $this->assertEquals('This is a command with no options', $command->getDescription());
-        $this->assertEquals("This command will concatinate two parameters.", $command->getHelp());
+        $this->assertEquals("This command will concatenate two parameters.", $command->getHelp());
         $this->assertEquals('nope', implode(',', $command->getAliases()));
         $this->assertEquals('command:with-no-options <one> [<two>]', $command->getSynopsis());
         $this->assertEquals('command:with-no-options alpha bet', implode(',', $command->getUsages()));


### PR DESCRIPTION
Pedantic spelling change for concatenate.