### PR TITLE
Annotation hooks

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -269,7 +269,8 @@ class AnnotatedCommand extends Command
         $results = $commandProcessor->processResults(
             $names,
             $results,
-            $args
+            $args,
+            $this->annotationData
         );
         $options = end($args);
         return $commandProcessor->handleResults(

--- a/src/AnnotationData.php
+++ b/src/AnnotationData.php
@@ -1,0 +1,15 @@
+<?php
+namespace Consolidation\AnnotatedCommand;
+
+class AnnotationData extends \ArrayObject
+{
+    public function get($key, $default)
+    {
+        return isset($this[$key]) ? $this[$key] : $default;
+    }
+
+    public function keys()
+    {
+        return array_keys($this->getArrayCopy());
+    }
+}

--- a/src/Parser/CommandInfo.php
+++ b/src/Parser/CommandInfo.php
@@ -3,6 +3,7 @@ namespace Consolidation\AnnotatedCommand\Parser;
 
 use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParser;
 use Consolidation\AnnotatedCommand\Parser\Internal\CommandDocBlockParserFactory;
+use Consolidation\AnnotatedCommand\AnnotationData;
 
 /**
  * Given a class and method name, parse the annotations in the
@@ -53,9 +54,9 @@ class CommandInfo
     protected $exampleUsage = [];
 
     /**
-     * @var array
+     * @var AnnotationData
      */
-    protected $otherAnnotations = [];
+    protected $otherAnnotations;
 
     /**
      * @var array
@@ -88,6 +89,7 @@ class CommandInfo
     {
         $this->reflection = new \ReflectionMethod($classNameOrInstance, $methodName);
         $this->methodName = $methodName;
+        $this->otherAnnotations = new AnnotationData();
         // Set up a default name for the command from the method name.
         // This can be overridden via @command or @name annotations.
         $this->name = $this->convertName($this->reflection->name);
@@ -147,7 +149,7 @@ class CommandInfo
      * implementation method of this command that are not already
      * handled by the primary methods of this class.
      *
-     * @return array
+     * @return AnnotationData
      */
     public function getAnnotations()
     {
@@ -179,7 +181,7 @@ class CommandInfo
     public function hasAnnotation($annotation)
     {
         $this->parseDocBlock();
-        return array_key_exists($annotation, $this->otherAnnotations);
+        return isset($this->otherAnnotations[$annotation]);
     }
 
     /**

--- a/tests/src/ExampleCommandFile.php
+++ b/tests/src/ExampleCommandFile.php
@@ -5,6 +5,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Consolidation\AnnotatedCommand\CommandError;
+use Consolidation\AnnotatedCommand\AnnotationData;
 
 /**
  * Test file used in the Annotation Factory tests.  It is also
@@ -157,6 +158,32 @@ class ExampleCommandFile
     public function hookTestHook($result)
     {
         return "<$result>";
+    }
+
+    /**
+     * This test is very similar to the preceding test, except
+     * it uses an annotation hook instead of a named-function hook.
+     *
+     * @hookme
+     * @before >
+     * @after <
+     */
+    public function testAnnotationHook($parameter)
+    {
+        return "($parameter)";
+    }
+
+    /**
+     * Wrap the results of test:hook in whatever the @before and @after
+     * annotations contain.
+     *
+     * @hook alter @hookme
+     */
+    public function hookTestAnnotatedHook($result, $args, AnnotationData $annotationData)
+    {
+        $before = $annotationData->get('before', '-');
+        $after = $annotationData->get('after', '-');
+        return "$before$result$after";
     }
 
     public function testHello($who)


### PR DESCRIPTION
Allows commands tagged with arbitrary annotations to use same for hooks.

e.g. `@hook pre-validate @authenticate` to run the hook function that follows on any command tagged `@authenticate` during the pre-validate phase.